### PR TITLE
DPI based resolution on Windows, gitignore and typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# NeutralinoJS related files
+.tmp
+bin

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # NeutralinoJS related files
 .tmp
 bin
+dist

--- a/neutralino.config.json
+++ b/neutralino.config.json
@@ -15,6 +15,8 @@
   "nativeAllowList": [
     "app.*",
     "os.*",
+    "computer.*",
+    "window.*",
     "filesystem.*",
     "debug.log"
   ],

--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -125,6 +125,7 @@ async function loadCards() {
     `;
 
   }
+
 }
 
 function showInfo(packageID) {

--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -44,6 +44,9 @@ async function forceRemoveDirectory(path) {
 
 async function updateResolution() {
 
+  if (NL_OS != "Windows")
+    return;
+
   let displays = await Neutralino.computer.getDisplays()
   let display = displays[0];
 

--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -44,20 +44,19 @@ async function forceRemoveDirectory(path) {
 
 async function updateResolution() {
 
-  if (NL_OS != "Windows")
-    return;
+  if (NL_OS === "Windows") return;
 
-  let displays = await Neutralino.computer.getDisplays()
-  let display = displays[0];
+  const display = (await Neutralino.computer.getDisplays())[0];
+  const config = await Neutralino.app.getConfig();
 
   // Recalculate resolution including screen size and dpi
-  let ogWidth = 800;
-  let ogHeightMultip = ogWidth / 500;
+  const ogWidth = config.modes.window.width;
+  const ogHeightMultip = ogWidth / config.modes.window.height;
 
-  let width = (display.dpi / 96) * // 96 dpi reference 
+  const width = (display.dpi / 96) * // 96 dpi reference 
               (display.resolution.width / 1920) *  // 1920 width reference
               ogWidth;
-  let height = width / ogHeightMultip; // 8:5 ratio
+  const height = width / ogHeightMultip; // 8:5 ratio
 
   Neutralino.window.setSize({width: width, height: height});
 

--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -42,8 +42,28 @@ async function forceRemoveDirectory(path) {
 
 }
 
+async function updateResolution() {
+
+  let displays = await Neutralino.computer.getDisplays()
+  let display = displays[0];
+
+  // Recalculate resolution including screen size and dpi
+  let ogWidth = 800;
+  let ogHeightMultip = ogWidth / 500;
+
+  let width = (display.dpi / 96) * // 96 dpi reference 
+              (display.resolution.width / 1920) *  // 1920 width reference
+              ogWidth;
+  let height = width / ogHeightMultip; // 8:5 ratio
+
+  Neutralino.window.setSize({width: width, height: height});
+
+}
+
 var index, activePackage = -1;
 async function loadCards() {
+
+  await updateResolution();
 
   const r = Math.floor(Math.random() * 1000); // Prevent caching
   let response = await fetch("https://p2r3.com/spplice/packages/index.php?r=" + r);
@@ -105,7 +125,6 @@ async function loadCards() {
     `;
 
   }
-
 }
 
 function showInfo(packageID) {

--- a/resources/js/modloader.js
+++ b/resources/js/modloader.js
@@ -137,7 +137,7 @@ async function installMod(path, packageID) {
     }
   } catch (e) {}
 
-  // Unistall and exit
+  // Uninstall and exit
   if(packageID < 0) return;
 
   // Get package repository URL


### PR DESCRIPTION
Added a small piece of code that scaled the resolution of the window with the dpi (on windows, this is the scale percentage) and resolution of the screen for the main monitor. Haven't found a way to do this once it moves onto another monitor.

Needs testing on linux I guess.

Another note, fetching the screen resolution with window.getSize() returns null for some reason, so the size needs to be entered in the code instead of read from the config. I'd keep minWidth and minHeight always the same.

gitignore is also kept very simple just to prevent pushing the wrong files in the future